### PR TITLE
UNRELIABLE VALUE warning fix when the parallel back-end is specified using the future package

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,3 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^\.travis\.yml$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Version: 1.4
 Date: 2013-12-31
 Author: Daniel J. Stekhoven <stekhoven@stat.math.ethz.ch>
 Maintainer: Daniel J. Stekhoven <stekhoven@stat.math.ethz.ch>
-Imports: randomForest,foreach,itertools,iterators
+Imports: randomForest,foreach,itertools,iterators,doRNG
 Suggests: doParallel
 Description: The function 'missForest' in this package is used to
         impute missing values particularly in the case of mixed-type

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Version: 1.4
 Date: 2013-12-31
 Author: Daniel J. Stekhoven <stekhoven@stat.math.ethz.ch>
 Maintainer: Daniel J. Stekhoven <stekhoven@stat.math.ethz.ch>
-Depends: randomForest,foreach,itertools
+Imports: randomForest,foreach,itertools,iterators
 Suggests: doParallel
 Description: The function 'missForest' in this package is used to
         impute missing values particularly in the case of mixed-type

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -14,3 +14,4 @@ import(
 
 importFrom(iterators,idiv)
 importFrom(doRNG,"%dorng%")
+importFrom("stats", "predict", "var")

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -11,3 +11,5 @@ import(
   foreach,
   itertools
 )
+
+importFrom(iterators,idiv)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -13,3 +13,4 @@ import(
 )
 
 importFrom(iterators,idiv)
+importFrom(doRNG,"%dorng%")

--- a/R/missForest.R
+++ b/R/missForest.R
@@ -119,7 +119,7 @@ missForest <- function(xmis, maxiter = 10, ntree = 100, variablewise = FALSE,
   ## compute a list of column indices for variable parallelization
   nzsort.j <- sort.j[sort.noNAvar > 0]
   if (parallelize == 'variables') {
-    '%cols%' <- get('%dopar%')
+    '%cols%' <- get('%dorng%')
     idxList <- as.list(isplitVector(nzsort.j, chunkSize = getDoParWorkers()))
   } 
   #   else {
@@ -254,7 +254,7 @@ missForest <- function(xmis, maxiter = 10, ntree = 100, variablewise = FALSE,
               xntree <- NULL
               RF <- foreach(xntree = idiv(ntree, chunks = getDoParWorkers()),
                             .combine = 'combine', .multicombine = TRUE,
-                            .packages = 'randomForest') %dopar% {
+                            .packages = 'randomForest') %dorng% {
                               randomForest( x = obsX,
                                             y = obsY,
                                             ntree = xntree,
@@ -291,7 +291,7 @@ missForest <- function(xmis, maxiter = 10, ntree = 100, variablewise = FALSE,
               if (parallelize == 'forests') {
                 RF <- foreach(xntree = idiv(ntree, chunks = getDoParWorkers()),
                               .combine = 'combine', .multicombine = TRUE,
-                              .packages = 'randomForest') %dopar% {
+                              .packages = 'randomForest') %dorng% {
                                 randomForest(
                                   x = obsX,
                                   y = obsY,


### PR DESCRIPTION
This is a fix for the following situation where the parallel back-end is specified using the [future]( https://CRAN.R-project.org/package=future) package that produces unreproducible imputations. 

```
> library(missForest)
> data(iris)
> 
> future::plan(future::multisession,workers = 2)
> doFuture::registerDoFuture()
> 
> set.seed(81)
> iris.mis <-  prodNA(iris, noNA = 0.2)
> 
> iris.imp <- missForest(iris.mis, 
+                        xtrue = iris, 
+                        parallelize = 'forests')
  missForest iteration 1 in progress...done!
  missForest iteration 2 in progress...done!
  missForest iteration 3 in progress...done!
  missForest iteration 4 in progress...done!
  missForest iteration 5 in progress...done!
  missForest iteration 6 in progress...done!
There were 50 or more warnings (use warnings() to see the first 50)
> 
> warnings()[1]
Warning message:
UNRELIABLE VALUE: One of the foreach() iterations (‘doFuture-1’) unexpectedly generated random numbers without declaring 
so. There is a risk that those random numbers are not statistically sound and the overall results might be invalid. To fix this, use 
'%dorng%' from the 'doRNG' package instead of '%dopar%'. This ensures that proper, parallel-safe random numbers are
produced via the L'Ecuyer-CMRG method. To disable this check, set option 'future.rng.onMisuse' to "ignore".
```
All occurances of `%dopar%` have been simply replaced with `%dorng%` as the warning suggests.
`missForest()` then no longer produces this warning and the imputed values are now reproducible.

Other minor fixes include:
* `idiv()`function is now correctly imported from the iterators package so that `missForest::missForest()` can be used without having to call `library(missForest)` beforehand.
* Changed the `Depends` field in the DESCRIPTION to `Imports` so that dependency packages are no longer attached when the package is loaded.