### PR TITLE
Improvements to parallel efficiency when argument `parallel = "variables"`

### DIFF
--- a/R/missForest.R
+++ b/R/missForest.R
@@ -73,9 +73,6 @@ missForest <- function(xmis, maxiter = 10, ntree = 100, variablewise = FALSE,
         cat("  parallelizing computation of the random forest model objects\n")
       }
     }
-    if (getDoParWorkers() > p){
-      stop("The number of parallel cores should not exceed the number of variables (p=", p, ")")
-    }
   }
   
   ## perform initial S.W.A.G. on xmis (mean imputation)


### PR DESCRIPTION
Parallel computation when argument `parallel = "variables"` is severely restricted by the prior chunking of variables into groups the size of the number of parallel workers. Parallel computation is then executed on each group at a time. This leads to very inefficient processing as the computation time of each group is always restricted to the time it takes to compute the slowest variable. If you look at a resource monitor whilst imputing a larger data set, you will see the CPU usage oscillates up and down as each group of variables is computed and the next group then starts.

The minor changes in this pull request provide improvements to the efficiency of parallel processing. In summary, these changes:

- Remove the unnecessary error that is thrown if the number of parallel cores exceeds the number of variables.
- Remove the throttling `for` loops placed around the calls to `foreach` when argument `parallel = "variables"`. This enables the load balancing to be fully controlled by the parallel back end that the user has specified and enables CPU load to be used more efficiently. 

An example is shown below comparing the current version with this pull request version. 

stekhoven/missForest@eb2f018674fb26a7956203fb3797745b3973bf56
```sh
R --vanilla --quiet -e "
  .libPaths(c(.libPaths(),tempdir()))
  install.packages(c('remotes','metaboData','doParallel'),lib = tempdir(),repos = 'https://cloud.r-project.org',quiet = TRUE)
  remotes::install_github('stekhoven/missForest@eb2f018674fb26a7956203fb3797745b3973bf56',lib = tempdir(),quiet = TRUE)
  doParallel::registerDoParallel(cores = 3)
  set.seed(81)
  data.mis <- missForest::prodNA(metaboData::abr1\$neg, noNA = 0.2)
  system.time(data.imp <- missForest::missForest(data.mis,parallel = 'variables'))
  "
> 
>   .libPaths(c(.libPaths(),tempdir()))
>   install.packages(c('remotes','metaboData','doParallel'),lib = tempdir(),repos = 'https://cloud.r-project.org',quiet = TRUE)
also installing the dependencies ‘sys’, ‘rappdirs’, ‘askpass’, ‘fastmap’, ‘bit’, ‘prettyunits’, ‘utf8’, ‘withr’, ‘gitcreds’, ‘httr2’, ‘ini’, ‘curl’, ‘mime’, ‘openssl’, ‘timechange’, ‘cachem’, ‘bit64’, ‘progress’, ‘cli’, ‘generics’, ‘glue’, ‘lifecycle’, ‘pillar’, ‘R6’, ‘tidyselect’, ‘vctrs’, ‘gh’, ‘httr’, ‘jsonlite’, ‘lubridate’, ‘memoise’, ‘clipr’, ‘crayon’, ‘hms’, ‘vroom’, ‘cpp11’, ‘tzdb’, ‘stringi’, ‘fansi’, ‘pkgconfig’, ‘dplyr’, ‘fs’, ‘magrittr’, ‘piggyback’, ‘purrr’, ‘readr’, ‘rlang’, ‘stringr’, ‘tibble’, ‘yaml’

>   remotes::install_github('stekhoven/missForest@eb2f018674fb26a7956203fb3797745b3973bf56',lib = tempdir(),quiet = TRUE)
Running `R CMD build`...
>   doParallel::registerDoParallel(cores = 3)
>   set.seed(81)
>   data.mis <- missForest::prodNA(metaboData::abr1$neg, noNA = 0.2)
>   system.time(data.imp <- missForest::missForest(data.mis,parallel = 'variables'))
randomForest 4.7-1.1
Type rfNews() to see new features/changes/bug fixes.
Loading required package: foreach
Loading required package: rngtools
    user   system  elapsed 
1629.331  138.672  755.709 
```

jasenfinch/missForest@135ec2981521f175493e8da0c24e7039f2aedbbc
```sh
R --vanilla --quiet -e "
  .libPaths(c(.libPaths(),tempdir()))
  install.packages(c('remotes','metaboData','doParallel'),lib = tempdir(),repos = 'https://cloud.r-project.org',quiet = TRUE)
  remotes::install_github('jasenfinch/missForest@135ec2981521f175493e8da0c24e7039f2aedbbc',lib = tempdir(),quiet = TRUE)
  doParallel::registerDoParallel(cores = 3)
  set.seed(81)
  data.mis <- missForest::prodNA(metaboData::abr1\$neg, noNA = 0.2)
  system.time(data.imp <- missForest::missForest(data.mis,parallel = 'variables'))
  "
> 
>   .libPaths(c(.libPaths(),tempdir()))
>   install.packages(c('remotes','metaboData','doParallel'),lib = tempdir(),repos = 'https://cloud.r-project.org',quiet = TRUE)
also installing the dependencies ‘sys’, ‘rappdirs’, ‘askpass’, ‘fastmap’, ‘bit’, ‘prettyunits’, ‘utf8’, ‘withr’, ‘gitcreds’, ‘httr2’, ‘ini’, ‘curl’, ‘mime’, ‘openssl’, ‘timechange’, ‘cachem’, ‘bit64’, ‘progress’, ‘cli’, ‘generics’, ‘glue’, ‘lifecycle’, ‘pillar’, ‘R6’, ‘tidyselect’, ‘vctrs’, ‘gh’, ‘httr’, ‘jsonlite’, ‘lubridate’, ‘memoise’, ‘clipr’, ‘crayon’, ‘hms’, ‘vroom’, ‘cpp11’, ‘tzdb’, ‘stringi’, ‘fansi’, ‘pkgconfig’, ‘dplyr’, ‘fs’, ‘magrittr’, ‘piggyback’, ‘purrr’, ‘readr’, ‘rlang’, ‘stringr’, ‘tibble’, ‘yaml’

>   remotes::install_github('jasenfinch/missForest@135ec2981521f175493e8da0c24e7039f2aedbbc',lib = tempdir(),quiet = TRUE)
Running `R CMD build`...
>   doParallel::registerDoParallel(cores = 3)
>   set.seed(81)
>   data.mis <- missForest::prodNA(metaboData::abr1$neg, noNA = 0.2)
>   system.time(data.imp <- missForest::missForest(data.mis,parallel = 'variables'))
randomForest 4.7-1.1
Type rfNews() to see new features/changes/bug fixes.
Loading required package: foreach
Loading required package: rngtools
    user   system  elapsed 
1663.954    3.148  580.153 
```

I have found that this can improve the computation time by up to about 33% in large data sets run on many cores.